### PR TITLE
Use .ini file to store configuration

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -1,23 +1,23 @@
 # Configuration Template for Weblog
-# Fill in your values and rename this file to config.yml
+# Fill in your values and rename this file to config.ini
 
 # Author's full name
-author_name: "John Doe"
+author_name = "John Doe"
 
 # Description about the author or the blog
-about_text: "I like trains."
+about_text = "I like trains."
 
 # Full domain URL without trailing slash
-domain: "https://example.com"
+domain = "https://example.com"
 
 # Line width for text formatting
-line_width: 72
+line_width = 72
 
 # Prefix length for paragraph formatting
-prefix_length: 3
+prefix_length = 3
 
 # Directory where blog files are stored
-weblog_dir: "/path/to/your/weblog/directory"
+weblog_dir = "/path/to/your/weblog/directory"
 
 # Author email for footer copyright
-author_email: "example@example.com"
+author_email = "example@example.com"

--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@
 class Weblog {
     private static $config = [];
     private const VERSION = '1.2.0';
-    private const CONFIG_PATH = __DIR__ . '/config.yml';
+    private const CONFIG_PATH = __DIR__ . '/config.ini';
     private const DEFAULT_LINE_WIDTH = 72;
     private const DEFAULT_PREFIX_LENGTH = 3;
     private const DEFAULT_WEBLOG_DIR = __DIR__ . '/weblog/';
@@ -78,17 +78,10 @@ class Weblog {
      * Loads configuration from a YAML file. Parses the file line-by-line and populates the config array.
      */
     private static function loadConfig() {
-        $configContent = file_get_contents(self::CONFIG_PATH);
-        $lines = explode("\n", $configContent);
-        foreach ($lines as $line) {
-            if (trim($line) && $line[0] !== '#' && strpos($line, ':') !== false) {
-                list($key, $value) = explode(':', $line, 2);
-                self::$config[trim($key)] = trim($value);
-            }
-        }
-        self::$config['line_width'] = self::$config['line_width'] ?? self::DEFAULT_LINE_WIDTH;
-        self::$config['prefix_length'] = self::$config['prefix_length'] ?? self::DEFAULT_PREFIX_LENGTH;
-        self::$config['weblog_dir'] = self::$config['weblog_dir'] ?? self::DEFAULT_WEBLOG_DIR;
+        self::$config = parse_ini_file(self::CONFIG_PATH);
+        self::$config['line_width'] ??= self::DEFAULT_LINE_WIDTH;
+        self::$config['prefix_length'] ??= self::DEFAULT_PREFIX_LENGTH;
+        self::$config['weblog_dir'] ??= self::DEFAULT_WEBLOG_DIR;
         self::$config['domain'] = rtrim(self::$config['domain'] ?? 'https://renecoignard.com', '/');
     }
 


### PR DESCRIPTION
Parsing YAML is hard. Unless we want to add a dependency to a proper YAML parser I think we're better off using INI files. For example with the current YAML implementation, something like the weblog directory in the provided config : 
```yaml
weblog_dir: "/path/to/your/weblog/directory"
```
would fail because the double quotes are not properly trimmed from the value.

Comments at the end of a line like this would also fail :
```yaml
author_name: "John Doe" # This is not my actual name
```


I also refactored the null coalescing operators to [null coalescing assignments](https://wiki.php.net/rfc/null_coalesce_equal_operator) for better readability, this is available since PHP 7.4 so I think it's safe to use.
